### PR TITLE
Adjusted to use go-plugin-api from Maven central

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -10,8 +10,6 @@
         <dependency org="junit" name="junit" rev="4.11"/>
         <dependency org="org.json" name="json" rev="20140107"/>
         <dependency org="org.mockito" name="mockito-all" rev="1.9.5"/>
-        <dependency org="com.thoughtworks" name="go-plugin-api" rev="current">
-            <artifact name="go-plugin-api" url="http://www.thoughtworks.com/products/docs/go/current/help/resources/go-plugin-api-current.jar"/>
-        </dependency>
+        <dependency org="cd.go.plugin" name="go-plugin-api" rev="14.4.0"/>
     </dependencies>
 </ivy-module>


### PR DESCRIPTION
Noticed that someone had raised an issue related to where the go-plugin-api jar is obtained from.

Updated ivy.xml to utilise the 14.4.0 jar